### PR TITLE
docs: storybook storysort option

### DIFF
--- a/packages/storybook/config/preview.tsx
+++ b/packages/storybook/config/preview.tsx
@@ -66,6 +66,9 @@ const preview: Preview = {
     },
     options: {
       panelPosition: 'right',
+      storySort: {
+        order: ['Rotterdam', 'CSS Component'],
+      },
     },
   },
 };


### PR DESCRIPTION
Rotterdam docs first. We can add the other segments in order if/when they get content.

<img width="1063" alt="image" src="https://github.com/nl-design-system/rotterdam/assets/24610692/82d656b0-ba0b-4313-9b49-c497ff0e2c04">
