### PR TITLE
feat: template viewport page content layout

### DIFF
--- a/packages/components-css/grid/index.scss
+++ b/packages/components-css/grid/index.scss
@@ -36,6 +36,8 @@
 @container (min-width: 48rem) {
   .rods-grid {
     grid-column-gap: 1.5rem;
+    padding-inline-end: 4.5rem;
+    padding-inline-start: 4.5rem;
   }
 
   .rods-grid__half-width {
@@ -51,9 +53,11 @@
   }
 }
 
-@container (min-width: 60rem) {
+@container (min-width: 64rem) {
   .rods-grid {
     grid-template-columns: repeat(12, 1fr);
+    padding-inline-end: 6rem;
+    padding-inline-start: 6rem;
   }
 
   .rods-grid__half-width {
@@ -70,5 +74,19 @@
 
   .rods-grid__one-fourth {
     grid-column: span 3;
+  }
+}
+
+@container (min-width: 80rem) {
+  .rods-grid {
+    padding-inline-end: 9rem;
+    padding-inline-start: 9rem;
+  }
+}
+
+@container (min-width: 105rem) {
+  .rods-grid {
+    padding-inline-end: 12rem;
+    padding-inline-start: 12rem;
   }
 }

--- a/packages/storybook/config/main.tsx
+++ b/packages/storybook/config/main.tsx
@@ -5,7 +5,7 @@ module.exports = {
     '@etchteam/storybook-addon-status/register',
     '@storybook/addon-a11y/register',
     '@storybook/addon-docs',
-    '@storybook/addon-viewport/register',
+    '@storybook/addon-viewport',
     '@storybook/preset-scss',
     '@storybook/addon-styling',
     '@storybook/addon-a11y',

--- a/packages/storybook/src/template/index.scss
+++ b/packages/storybook/src/template/index.scss
@@ -1,3 +1,14 @@
 .utrecht-breadcrumb-nav {
   margin-inline-start: calc(-1 * var(--utrecht-breadcrumb-nav-item-padding-inline-start, 8px));
 }
+
+.example-card-group {
+  column-gap: 2rem;
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.example-card {
+  border: 1px solid #ccc;
+  flex: 1 1 calc(50% - 2rem);
+}

--- a/packages/storybook/src/template/index.scss
+++ b/packages/storybook/src/template/index.scss
@@ -2,6 +2,25 @@
   margin-inline-start: calc(-1 * var(--utrecht-breadcrumb-nav-item-padding-inline-start, 8px));
 }
 
+.example-footer {
+  border-block-start: 3px solid #00811f;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  margin-block-start: 3rem;
+  padding-block-start: 1.5rem;
+}
+
+.example-footer__navbar {
+  align-items: center;
+  display: flex;
+}
+
+.example-footer__logo {
+  block-size: 48px;
+  inline-size: 240px;
+}
+
 .example-card-group {
   column-gap: 2rem;
   display: flex;

--- a/packages/storybook/src/template/page-mijn-loket.stories.tsx
+++ b/packages/storybook/src/template/page-mijn-loket.stories.tsx
@@ -25,6 +25,21 @@ import {
 const meta = {
   title: 'Template/Mijn Loket',
   id: 'template-mijn-loket',
+  parameters: {
+    viewport: {
+      viewports: {
+        desktop: {
+          name: 'Desktop',
+          styles: {
+            width: '1280px',
+            height: '1528px',
+          },
+        },
+      },
+      defaultViewport: 'desktop',
+    },
+  },
+  decorators: [(Story) => <div style={{ minInlineSize: '1280px' }}>{Story()}</div>],
 } satisfies Meta;
 
 export default meta;

--- a/packages/storybook/src/template/page-mijn-loket.stories.tsx
+++ b/packages/storybook/src/template/page-mijn-loket.stories.tsx
@@ -14,6 +14,7 @@ import {
   RodsIconParking,
   RodsIconSummary,
   RodsIconUser,
+  RodsLogoImage,
 } from '@gemeente-rotterdam/web-components-react';
 import { Meta, StoryObj } from '@storybook/react';
 import '@gemeente-rotterdam/components-css/grid/index.scss';
@@ -238,6 +239,12 @@ export const Default: Story = {
             </div>
           </section>
         </div>
+        <footer className={'example-footer rods-grid__full-width'}>
+          <div className={'example-footer__navbar'}>navbar links</div>
+          <div className={'example-footer__logo'}>
+            <RodsLogoImage />
+          </div>
+        </footer>
       </div>
     </div>
   ),

--- a/packages/storybook/src/template/page-mijn-loket.stories.tsx
+++ b/packages/storybook/src/template/page-mijn-loket.stories.tsx
@@ -3,8 +3,11 @@
 import { ActionSingle } from '@gemeente-denhaag/action';
 import { Sidenav, SidenavItem, SidenavLink, SidenavList } from '@gemeente-denhaag/sidenav';
 import {
+  RodsIconArrowRight,
   RodsIconBox,
   RodsIconCoins,
+  RodsIconDocument,
+  RodsIconEnvelope,
   RodsIconInbox,
   RodsIconMoney2,
   RodsIconOverview,
@@ -174,6 +177,65 @@ export const Default: Story = {
           </section>
           <section>
             <h2>Zelf regelen</h2>
+            <div className={'example-card-group'}>
+              <div className={'example-card'}>
+                <RodsIconDocument />
+                <p className={'example-card-title'}>Passport vernieuwen of aanvragen</p>
+                <div className={'example-link-list'}>
+                  <a className={'example-link'} href={'#'}>
+                    <RodsIconArrowRight />
+                    Direct regelen
+                  </a>
+                  <a className={'example-link'} href={'#'}>
+                    <RodsIconArrowRight />
+                    Meer informatie op Rotterdam.nl
+                  </a>
+                </div>
+              </div>
+              <div className={'example-card'}>
+                <RodsIconParking />
+                <p className={'example-card-title'}>Parkeervergunning aanvragen of beheren</p>
+                <div className={'example-link-list'}>
+                  <a className={'example-link'} href={'#'}>
+                    <RodsIconArrowRight />
+                    Direct regelen
+                  </a>
+                  <a className={'example-link'} href={'#'}>
+                    <RodsIconArrowRight />
+                    Meer informatie op Rotterdam.nl
+                  </a>
+                </div>
+              </div>
+
+              <div className={'example-card'}>
+                <RodsIconEnvelope />
+                <p className={'example-card-title'}>Belastingzaken</p>
+                <div className={'example-link-list'}>
+                  <a className={'example-link'} href={'#'}>
+                    <RodsIconArrowRight />
+                    Direct regelen
+                  </a>
+                  <a className={'example-link'} href={'#'}>
+                    <RodsIconArrowRight />
+                    Meer informatie op Rotterdam.nl
+                  </a>
+                </div>
+              </div>
+              <div className={'example-card'}>
+                <RodsIconEnvelope />
+                <p className={'example-card-title'}>Belastingzaken</p>
+                <div className={'example-link-list'}>
+                  <a className={'example-link'} href={'#'}>
+                    <RodsIconArrowRight />
+                    Direct regelen
+                  </a>
+                  <a className={'example-link'} href={'#'}>
+                    <RodsIconArrowRight />
+                    Meer informatie op Rotterdam.nl
+                  </a>
+                </div>
+              </div>
+            </div>
           </section>
         </div>
       </div>


### PR DESCRIPTION
- Sets viewport to specific desktop size
- Adds correct inline whitespace for grid for different screen sizes
- Adds temporary card layout group
- Adds footer (temp example code), not sure if we want to just modify the utrecht one with a new appeance modifier.. `utrecht-footer--appearance-light` because the current theme tokens are green, which is not for the portal.

<img width="1343" alt="image" src="https://github.com/nl-design-system/rotterdam/assets/24610692/bcf243b3-003b-4651-ba61-15ee4fbe34f4">
