### PR TITLE
feat: add header

### DIFF
--- a/packages/storybook/src/template/index.scss
+++ b/packages/storybook/src/template/index.scss
@@ -14,10 +14,22 @@ rods-logo-image {
 }
 
 .example-page-header__top-bar {
+  align-items: center;
   background-color: var(--rods-color-base-gray);
+  block-size: 3rem;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  padding-inline-end: 6rem;
+  padding-inline-start: 6rem;
 }
 
 .example-page-header__content {
+  align-items: center;
+  block-size: 6rem;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
   padding-inline-end: 6rem;
   padding-inline-start: 6rem;
 }
@@ -44,6 +56,20 @@ rods-logo-image {
 .example-footer__navbar {
   align-items: center;
   display: flex;
+}
+
+.utrecht-link--backlink {
+  --utrecht-icon-size: var(--rods-typography-scale-md-font-size);
+  --utrecht-icon-color: var(--rods-color-gray-tint-06);
+  --utrecht-link-text-decoration: none;
+  --utrecht-link-hover-text-decoration: underline;
+
+  align-items: center;
+  color: var(--rods-color-gray-tint-11);
+  column-gap: var(--rods-space-scale-1);
+  display: flex;
+  font-size: var(--rods-typography-scale-sm-font-size);
+  line-height: var(--rods-typography-scale-sm-line-height);
 }
 
 .example-card-group {

--- a/packages/storybook/src/template/index.scss
+++ b/packages/storybook/src/template/index.scss
@@ -7,6 +7,12 @@
   margin-block-end: 1.5rem;
 }
 
+rods-logo-image {
+  block-size: 48px;
+  display: inline-block;
+  inline-size: 240px;
+}
+
 .example-page-header__top-bar {
   background-color: var(--rods-color-base-gray);
 }
@@ -38,11 +44,6 @@
 .example-footer__navbar {
   align-items: center;
   display: flex;
-}
-
-.example-footer__logo {
-  block-size: 48px;
-  inline-size: 240px;
 }
 
 .example-card-group {

--- a/packages/storybook/src/template/index.scss
+++ b/packages/storybook/src/template/index.scss
@@ -2,8 +2,32 @@
   margin-inline-start: calc(-1 * var(--utrecht-breadcrumb-nav-item-padding-inline-start, 8px));
 }
 
+.utrecht-page-header {
+  border-block-end: 1px solid var(--rods-color-gray-tint-04);
+  margin-block-end: 1.5rem;
+}
+
+.example-page-header__top-bar {
+  background-color: var(--rods-color-base-gray);
+}
+
+.example-page-header__content {
+  padding-inline-end: 6rem;
+  padding-inline-start: 6rem;
+}
+
+/*
+  // padding idea for screen sizes where content size caps out
+  // -4rem is for the header content alignment which start 64px left of the page content start
+  @media (min-width: 1564px) {
+    .example-page-header-content {
+      padding-inline-start: calc((100vw - 1180px) / 2 - 4rem);
+    }
+  }
+ */
+
 .example-footer {
-  border-block-start: 3px solid #00811f;
+  border-block-start: 3px solid var(--rods-color-base-green);
   display: flex;
   flex-direction: row;
   justify-content: space-between;

--- a/packages/storybook/src/template/page-mijn-loket.stories.tsx
+++ b/packages/storybook/src/template/page-mijn-loket.stories.tsx
@@ -3,6 +3,7 @@
 import { ActionSingle } from '@gemeente-denhaag/action';
 import { Sidenav, SidenavItem, SidenavLink, SidenavList } from '@gemeente-denhaag/sidenav';
 import {
+  RodsIconArrowLeft,
   RodsIconArrowRight,
   RodsIconBox,
   RodsIconCoins,
@@ -24,6 +25,7 @@ import {
   BreadcrumbNav,
   BreadcrumbNavLink,
   BreadcrumbNavSeparator,
+  Link,
   PageHeader,
 } from '@utrecht/component-library-react/dist/css-module';
 
@@ -56,9 +58,16 @@ export const Default: Story = {
   render: (args) => (
     <div {...args} style={{ containerType: 'inline-size' }}>
       <PageHeader>
-        <div className="example-page-header__top-bar">top bar</div>
+        <div className="example-page-header__top-bar">
+          <Link href="#" className="utrecht-link--backlink">
+            <RodsIconArrowLeft />
+            Rotterdam.nl
+          </Link>
+          <div>Nav list here</div>
+        </div>
         <div className="example-page-header__content">
           <RodsLogoImage className="example-page-header__logo" />
+          <div>Nav buttons here</div>
         </div>
       </PageHeader>
       <div className={'rods-grid'}>

--- a/packages/storybook/src/template/page-mijn-loket.stories.tsx
+++ b/packages/storybook/src/template/page-mijn-loket.stories.tsx
@@ -57,7 +57,9 @@ export const Default: Story = {
     <div {...args} style={{ containerType: 'inline-size' }}>
       <PageHeader>
         <div className="example-page-header__top-bar">top bar</div>
-        <div className="example-page-header__content">main content</div>
+        <div className="example-page-header__content">
+          <RodsLogoImage className="example-page-header__logo" />
+        </div>
       </PageHeader>
       <div className={'rods-grid'}>
         <div className={'rods-grid__one-fourth'}>
@@ -245,9 +247,9 @@ export const Default: Story = {
             </div>
           </section>
         </div>
-        <footer className={'example-footer rods-grid__full-width'}>
-          <div className={'example-footer__navbar'}>navbar links</div>
-          <div className={'example-footer__logo'}>
+        <footer className="example-footer rods-grid__full-width">
+          <div className="example-footer__navbar">navbar links</div>
+          <div>
             <RodsLogoImage />
           </div>
         </footer>

--- a/packages/storybook/src/template/page-mijn-loket.stories.tsx
+++ b/packages/storybook/src/template/page-mijn-loket.stories.tsx
@@ -24,12 +24,14 @@ import {
   BreadcrumbNav,
   BreadcrumbNavLink,
   BreadcrumbNavSeparator,
+  PageHeader,
 } from '@utrecht/component-library-react/dist/css-module';
 
 const meta = {
   title: 'Template/Mijn Loket',
   id: 'template-mijn-loket',
   parameters: {
+    layout: 'fullscreen',
     viewport: {
       viewports: {
         desktop: {
@@ -53,6 +55,10 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   render: (args) => (
     <div {...args} style={{ containerType: 'inline-size' }}>
+      <PageHeader>
+        <div className="example-page-header__top-bar">top bar</div>
+        <div className="example-page-header__content">main content</div>
+      </PageHeader>
       <div className={'rods-grid'}>
         <div className={'rods-grid__one-fourth'}>
           <Sidenav>


### PR DESCRIPTION
- Use `utrechtt-page-header`
- Add `rods-logo-image`
- Add default size for `rods-logo-image` custom element (the logo size for footer and header are the same)
- Add inner header content which consists of a `topbar` and `content`
- Add backlink modifier for utrecht-link (needs to be sorted out neatly how this should work)
- Add slots for nav lists

<img width="1308" alt="image" src="https://github.com/nl-design-system/rotterdam/assets/24610692/93226628-6394-468b-8999-8529ffbf86fc">