### PR TITLE
feat: add nav-bar button menu for main actions

### DIFF
--- a/packages/storybook/src/template/index.scss
+++ b/packages/storybook/src/template/index.scss
@@ -7,11 +7,23 @@
   margin-block-end: 1.5rem;
 }
 
+.utrecht-nav-bar {
+  font-size: var(--rods-typography-scale-sm-font-size);
+}
+
+.utrecht-nav-bar--button-menu {
+  --utrecht-nav-list-column-gap: 1.5rem; /* no space token for 24px */
+  --utrecht-nav-list-link-current-border-block-end: 4px solid var(--rods-color-base-green);
+
+  block-size: 100%;
+  font-size: var(--rods-typography-scale-md-font-size);
+}
+
 .utrecht-nav-list {
   --utrecht-link-color: var(--utrecht-nav-bar-color);
   --utrecht-link-text-decoration: none;
 
-  font-size: var(--rods-typography-scale-sm-font-size);
+  column-gap: var(--utrecht-nav-list-column-gap, 0);
 }
 
 @mixin utrecht-link--with-icon {
@@ -33,6 +45,16 @@ when classNames has a value */
   @include utrecht-link--with-icon;
 
   --utrecht-link-icon-size: var(--rods-typography-scale-lg-font-size);
+}
+
+.utrecht-nav-list__link[aria-current="page"] {
+  border-block-end: var(--utrecht-nav-list-link-current-border-block-end);
+}
+
+.utrecht-nav-bar--button-menu .utrecht-nav-list__link {
+  --utrecht-link-icon-size: var(--rods-typography-scale-3xl-font-size);
+
+  column-gap: var(--rods-space-scale-2);
 }
 
 .utrecht-link--backlink {

--- a/packages/storybook/src/template/page-mijn-loket.stories.tsx
+++ b/packages/storybook/src/template/page-mijn-loket.stories.tsx
@@ -12,9 +12,11 @@ import {
   RodsIconGlobe,
   RodsIconInbox,
   RodsIconLogOut,
+  RodsIconMijnLoket,
   RodsIconMoney2,
   RodsIconOverview,
   RodsIconParking,
+  RodsIconSearch,
   RodsIconShoppingCart,
   RodsIconSummary,
   RodsIconUser,
@@ -93,7 +95,18 @@ export const Default: Story = {
         </div>
         <div className="example-page-header__content">
           <RodsLogoImage className="example-page-header__logo" />
-          <div>Nav buttons here</div>
+          <div className="utrecht-nav-bar utrecht-nav-bar--button-menu">
+            <NavList>
+              <NavListLink href="#">
+                <RodsIconSearch />
+                Zoeken
+              </NavListLink>
+              <NavListLink href="#" aria-current="page">
+                <RodsIconMijnLoket />
+                Mijn Loket
+              </NavListLink>
+            </NavList>
+          </div>
         </div>
       </PageHeader>
       <div className={'rods-grid'}>


### PR DESCRIPTION
**NOTE! PR is targeting the branch its based on for easier diff, change to main before merging and merge [this PR first](https://github.com/nl-design-system/rotterdam/pull/144)**

### Description
This one asks a lot of the `utrecht-nav-bar` and inner components to support a secondary "action" like style. This might be better off being it's own component later instead of bloating Utrecht css or extending it too much.

### Changes
- Set nav-list item font-size through the higher level `utrecht-nav-bar`. This is so we can add a modifier `--button-menu` which has a different unique font-size. (No tokens yet because Utrecht does not actually support this secondary navlist style)
- Add column gap which is also set by the `--button-menu` modifier
- Add styling for `aria-current="page"` (green underline)
- Support specific  link icon size for these bigger buttons

### Implementation
<img width="1195" alt="image" src="https://github.com/nl-design-system/rotterdam/assets/24610692/6d86fa50-2551-416a-afc7-70773ca49cf2">
