### PR TITLE
feat: add spacing and borders to card group

### DIFF
--- a/packages/storybook/src/template/index.scss
+++ b/packages/storybook/src/template/index.scss
@@ -123,13 +123,18 @@ rods-logo-image {
 }
 
 .example-card-group {
+  --example-card-icon-color: var(--rods-color-base-green);
+  --example-card-icon-size: 3rem;
   --example-card-border-width: 4px;
   --example-card-border-color: var(--rods-color-gray-tint-04);
+  --example-card-title-font-size: var(--rods-typography-scale-lg-font-size);
+  --example-card-title-line-height: var(--rods-typography-scale-lg-line-height);
   --example-card-group-gap: var(--rods-space-scale-4);
 
   column-gap: var(--example-card-group-gap);
   display: flex;
   flex-wrap: wrap;
+  font-weight: 700;
   row-gap: var(--example-card-group-gap);
 }
 
@@ -148,4 +153,22 @@ rods-logo-image {
     fill: currentColor !important;
     stroke: currentColor !important;
   }
+}
+
+.example-card__icon {
+  --utrecht-icon-size: 3rem;
+  --utrecht-icon-color: var(--example-card-icon-color);
+
+  line-height: 0;
+}
+
+.example-card__title {
+  font-size: var(--example-card-title-font-size);
+  line-height: var(--example-card-title-line-height);
+  margin-block-end: 1.5rem;
+  margin-block-start: 0.5rem;
+}
+
+.example-card-group .utrecht-link-list {
+  --utrecht-link-text-decoration: underline;
 }

--- a/packages/storybook/src/template/index.scss
+++ b/packages/storybook/src/template/index.scss
@@ -123,14 +123,23 @@ rods-logo-image {
 }
 
 .example-card-group {
-  column-gap: 2rem;
+  --example-card-border-width: 4px;
+  --example-card-border-color: var(--rods-color-gray-tint-04);
+  --example-card-group-gap: var(--rods-space-scale-4);
+
+  column-gap: var(--example-card-group-gap);
   display: flex;
   flex-wrap: wrap;
+  row-gap: var(--example-card-group-gap);
 }
 
 .example-card {
-  border: 1px solid #ccc;
-  flex: 1 1 calc(50% - 2rem);
+  border: var(--example-card-border-width) solid var(--example-card-border-color);
+  flex: 1 1 calc(50% - 64px);
+  padding-block-end: calc(2rem - var(--example-card-border-width));
+  padding-block-start: calc(1.5rem - var(--example-card-border-width));
+  padding-inline-end: calc(1.5rem - var(--example-card-border-width));
+  padding-inline-start: calc(1.5rem - var(--example-card-border-width));
 }
 
 .denhaag-action__warning-icon {

--- a/packages/storybook/src/template/page-mijn-loket.stories.tsx
+++ b/packages/storybook/src/template/page-mijn-loket.stories.tsx
@@ -235,10 +235,12 @@ export const Default: Story = {
           </section>
           <section>
             <h2>Zelf regelen</h2>
-            <div className={'example-card-group'}>
-              <div className={'example-card'}>
-                <RodsIconDocument />
-                <p className={'example-card-title'}>Passport vernieuwen of aanvragen</p>
+            <div className="example-card-group">
+              <div className="example-card">
+                <div className="example-card__icon">
+                  <RodsIconDocument />
+                </div>
+                <p className="example-card__title">Passport vernieuwen of aanvragen</p>
                 <LinkList
                   icon={() => <RodsIconArrowRight />}
                   links={[
@@ -247,9 +249,11 @@ export const Default: Story = {
                   ]}
                 />
               </div>
-              <div className={'example-card'}>
-                <RodsIconParking />
-                <p className={'example-card-title'}>Parkeervergunning aanvragen of beheren</p>
+              <div className="example-card">
+                <div className="example-card__icon">
+                  <RodsIconParking />
+                </div>
+                <p className="example-card__title">Parkeervergunning aanvragen of beheren</p>
                 <LinkList
                   icon={() => <RodsIconArrowRight />}
                   links={[
@@ -258,10 +262,11 @@ export const Default: Story = {
                   ]}
                 />
               </div>
-
-              <div className={'example-card'}>
-                <RodsIconEnvelope />
-                <p className={'example-card-title'}>Belastingzaken</p>
+              <div className="example-card">
+                <div className="example-card__icon">
+                  <RodsIconEnvelope />
+                </div>
+                <p className="example-card__title">Belastingzaken</p>
                 <LinkList
                   icon={() => <RodsIconArrowRight />}
                   links={[
@@ -270,9 +275,11 @@ export const Default: Story = {
                   ]}
                 />
               </div>
-              <div className={'example-card'}>
-                <RodsIconEnvelope />
-                <p className={'example-card-title'}>Belastingzaken</p>
+              <div className="example-card">
+                <div className="example-card__icon">
+                  <RodsIconEnvelope />
+                </div>
+                <p className="example-card__title">Belastingzaken</p>
                 <LinkList
                   icon={() => <RodsIconArrowRight />}
                   links={[


### PR DESCRIPTION
- Fixes up layout, borders and padding
- Adds example design tokens (by popular demand. Most of these are suggestions, but makes it easier to turn it into a proper component :D) 
- Adds styling to title and icon elements
- Add styling override for utrecht link list text underline (missing design token)

### Implementation
<img width="846" alt="image" src="https://github.com/nl-design-system/rotterdam/assets/24610692/89b877f9-cee1-4813-8b56-132657f43a31">
