### PR TITLE
fix: margins and paddings

### DIFF
--- a/packages/storybook/src/css-utrecht-breadcrumb-nav.stories.tsx
+++ b/packages/storybook/src/css-utrecht-breadcrumb-nav.stories.tsx
@@ -57,7 +57,6 @@ export const Default: Story = {
       <BreadcrumbNavLink href="/a/" index={1}>
         Parkeren in Rotterdam
       </BreadcrumbNavLink>,
-      // TODO: Use icon when iconset is available
       <BreadcrumbNavSeparator>
         <RodsIconChevronRight />
       </BreadcrumbNavSeparator>,

--- a/packages/storybook/src/template/index.scss
+++ b/packages/storybook/src/template/index.scss
@@ -166,6 +166,14 @@ rods-logo-image {
   --utrecht-link-text-decoration: underline;
 }
 
+.example-section {
+  margin-block-start: var(--rods-space-scale-4);
+}
+
+.example-section + .example-section {
+  margin-block-start: var(--rods-space-scale-5);
+}
+
 /* Den haag component overrides */
 .denhaag-action__warning-icon {
   g,

--- a/packages/storybook/src/template/index.scss
+++ b/packages/storybook/src/template/index.scss
@@ -109,6 +109,7 @@ rods-logo-image {
   flex-direction: row;
   justify-content: space-between;
   margin-block-start: 3rem;
+  padding-block-end: 1.5rem;
   padding-block-start: 1.5rem;
 }
 

--- a/packages/storybook/src/template/index.scss
+++ b/packages/storybook/src/template/index.scss
@@ -166,10 +166,6 @@ rods-logo-image {
   --utrecht-link-text-decoration: underline;
 }
 
-.example-section {
-  margin-block-start: var(--rods-space-scale-4);
-}
-
 .example-section + .example-section {
   margin-block-start: var(--rods-space-scale-5);
 }
@@ -188,4 +184,8 @@ rods-logo-image {
   --utrecht-icon-color: var(--denhaag-sidenav-link-color);
 
   background-color: var(--rods-color-gray-tint-01);
+}
+
+.rods-grid--margin-block-start {
+  margin-block-start: var(--rods-space-scale-3);
 }

--- a/packages/storybook/src/template/page-mijn-loket.stories.tsx
+++ b/packages/storybook/src/template/page-mijn-loket.stories.tsx
@@ -6,6 +6,7 @@ import {
   RodsIconArrowLeft,
   RodsIconArrowRight,
   RodsIconBox,
+  RodsIconChevronRight,
   RodsIconCoins,
   RodsIconDocument,
   RodsIconEnvelope,
@@ -119,11 +120,15 @@ export const Default: Story = {
             <BreadcrumbNavLink href="/" rel="home" index={0}>
               Home
             </BreadcrumbNavLink>
-            <BreadcrumbNavSeparator>›</BreadcrumbNavSeparator>
+            <BreadcrumbNavSeparator>
+              <RodsIconChevronRight />
+            </BreadcrumbNavSeparator>
             <BreadcrumbNavLink href="/a/" index={1}>
               Parkeren in Rotterdam
             </BreadcrumbNavLink>
-            <BreadcrumbNavSeparator>›</BreadcrumbNavSeparator>
+            <BreadcrumbNavSeparator>
+              <RodsIconChevronRight />
+            </BreadcrumbNavSeparator>
             <BreadcrumbNavLink href="/a/b/" rel="up" index={2} disabled current>
               Product aanvragen
             </BreadcrumbNavLink>
@@ -245,7 +250,7 @@ export const Default: Story = {
                 <div className="example-card__icon">
                   <RodsIconDocument />
                 </div>
-                <Paragraph className="example-card__title">Passport vernieuwen of aanvragen</Paragraph>
+                <Paragraph className="example-card__title">Pasport vernieuwen of aanvragen</Paragraph>
                 <LinkList
                   icon={() => <RodsIconArrowRight />}
                   links={[

--- a/packages/storybook/src/template/page-mijn-loket.stories.tsx
+++ b/packages/storybook/src/template/page-mijn-loket.stories.tsx
@@ -179,7 +179,7 @@ export const Default: Story = {
               Product aanvragen
             </BreadcrumbNavLink>
           </BreadcrumbNav>
-          <section>
+          <section className="example-section">
             <h1>Hallo mevrouw van Bergenhenegouwen</h1>
             <Paragraph>
               Via Mijn Loket kunt u veel zelf regelen met de gemeente. Bijvoorbeeld een afspraak maken om uw paspoort te
@@ -187,7 +187,7 @@ export const Default: Story = {
               van u vragen. Bijvoorbeeld het betalen van gemeentelijke belastingen. Zie hiervoor ‘Wat ik moet regelen’.
             </Paragraph>
           </section>
-          <section>
+          <section className="example-section">
             <h2>Wat moet ik regelen</h2>
             <div>
               <ActionSingle
@@ -234,7 +234,7 @@ export const Default: Story = {
               </ActionSingle>
             </div>
           </section>
-          <section>
+          <section className="example-section">
             <h2>Zelf regelen</h2>
             <div className="example-card-group">
               <div className="example-card">

--- a/packages/storybook/src/template/page-mijn-loket.stories.tsx
+++ b/packages/storybook/src/template/page-mijn-loket.stories.tsx
@@ -25,6 +25,7 @@ import {
 import { Meta, StoryObj } from '@storybook/react';
 import '@gemeente-rotterdam/components-css/grid/index.scss';
 import './index.scss';
+import { Heading1 } from '@utrecht/component-library-react';
 import {
   BadgeCounter,
   BreadcrumbNav,
@@ -111,8 +112,24 @@ export const Default: Story = {
           </div>
         </div>
       </PageHeader>
-      <div className={'rods-grid'}>
-        <div className={'rods-grid__one-fourth'}>
+      <div className="rods-grid">
+        <div className="rods-grid__one-fourth"></div>
+        <div className="rods-grid__two-third">
+          <BreadcrumbNav>
+            <BreadcrumbNavLink href="/" rel="home" index={0}>
+              Home
+            </BreadcrumbNavLink>
+            <BreadcrumbNavSeparator>›</BreadcrumbNavSeparator>
+            <BreadcrumbNavLink href="/a/" index={1}>
+              Parkeren in Rotterdam
+            </BreadcrumbNavLink>
+            <BreadcrumbNavSeparator>›</BreadcrumbNavSeparator>
+            <BreadcrumbNavLink href="/a/b/" rel="up" index={2} disabled current>
+              Product aanvragen
+            </BreadcrumbNavLink>
+          </BreadcrumbNav>
+        </div>
+        <div className={'rods-grid__one-fourth rods-grid--margin-block-start'}>
           <Sidenav>
             <SidenavList>
               <SidenavItem>
@@ -165,22 +182,9 @@ export const Default: Story = {
             </SidenavList>
           </Sidenav>
         </div>
-        <div className={'rods-grid__two-third'}>
-          <BreadcrumbNav>
-            <BreadcrumbNavLink href="/" rel="home" index={0}>
-              Home
-            </BreadcrumbNavLink>
-            <BreadcrumbNavSeparator>›</BreadcrumbNavSeparator>
-            <BreadcrumbNavLink href="/a/" index={1}>
-              Parkeren in Rotterdam
-            </BreadcrumbNavLink>
-            <BreadcrumbNavSeparator>›</BreadcrumbNavSeparator>
-            <BreadcrumbNavLink href="/a/b/" rel="up" index={2} disabled current>
-              Product aanvragen
-            </BreadcrumbNavLink>
-          </BreadcrumbNav>
+        <div className={'rods-grid__two-third rods-grid--margin-block-start'}>
           <section className="example-section">
-            <h1>Hallo mevrouw van Bergenhenegouwen</h1>
+            <Heading1>Hallo mevrouw van Bergenhenegouwen</Heading1>
             <Paragraph>
               Via Mijn Loket kunt u veel zelf regelen met de gemeente. Bijvoorbeeld een afspraak maken om uw paspoort te
               verlengen, of een subsidie aanvraag indienen. U kunt ook zien welke dingen u nog moet regelen of die wij

--- a/proprietary/design-tokens/src/common/utrecht/space.tokens.json
+++ b/proprietary/design-tokens/src/common/utrecht/space.tokens.json
@@ -1,6 +1,7 @@
 {
   "utrecht": {
     "space": {
+      "around": { "value": 1 },
       "block": {
         "3xs": { "value": "0" },
         "2xs": { "value": "4px" },

--- a/proprietary/design-tokens/src/component/utrecht/heading-1.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/heading-1.tokens.json
@@ -3,10 +3,10 @@
     "heading-1": {
       "color": {},
       "font-family": {},
-      "font-size": { "value": "{rods.typography.scale.6xl.font-size}" },
+      "font-size": { "value": "{rods.typography.scale.3xl.font-size}" },
       "font-weight": {},
-      "line-height": { "value": "{rods.typography.scale.6xl.line-height}" },
-      "margin-block-end": {},
+      "line-height": { "value": "{rods.typography.scale.3xl.line-height}" },
+      "margin-block-end": { "value": "{rods.space.scale.2}" },
       "margin-block-start": {}
     }
   }


### PR DESCRIPTION
**Merge https://github.com/nl-design-system/rotterdam/pull/150 first**

- Adds the correct margins to (between) sections sections
- Adds padding-block-end to footer
- Adds correct content start padding for grid sections with main content
- Sets correct sidenav alignement (top row only for breadcrumb)
- Sets heading 1 correctly with fixed font size and margin

<img width="1207" alt="image" src="https://github.com/nl-design-system/rotterdam/assets/24610692/adb9cc4b-4c31-4f5c-b762-1fb0dab8bef6">
