### PR TITLE
build: update visual-regression-test job

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -149,8 +149,9 @@ jobs:
         with:
           autoAcceptChanges: main
           exitOnceUploaded: true
-          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           storybookBuildDir: packages/storybook/dist/
+        env:
+          CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
 
   publish-website:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pass the CHROMATIC_PROJECT_TOKEN as an env variable instead of as a "projectToken" input for the action.

This way it can also be provided by Dependabot where it has also been added as a secret.