### PR TITLE
build: limit Dependabot pull requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,5 @@
 version: 2
 
-# Documentation:
-# https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/enabling-and-disabling-version-updates
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -13,10 +11,25 @@ updates:
       - "nl-design-system/kernteam-dependabot"
   - package-ecosystem: "npm"
     directory: "/"
+    # Only have Dependabot to create pull requests for these dependencies
+    # to prevent using up Chromatic screenshots
+    allow:
+      - dependency-name: "@gemeente-rotterdam/*"
+      - dependency-name: "@gemeente-denhaag/*"
+      - dependency-name: "@utrecht/*"
+      - dependency-name: "@nl-design-system/*"
+      - dependency-name: "@nl-design-system-unstable/*"
+    # Bundle the above dependencies into a single pull request
+    groups:
+      allowed-deps:
+        patterns:
+          - "@gemeente-rotterdam/*"
+          - "@gemeente-utrecht/*"
+          - "@utrecht/*"
+          - "@nl-design-system/*"
+          - "@nl-design-system-unstable/*"
     schedule:
       interval: "monthly"
-      time: "09:00"
-      timezone: "Europe/Amsterdam"
     versioning-strategy: "increase-if-necessary"
     open-pull-requests-limit: 20
     reviewers:


### PR DESCRIPTION
Pull requests that are opened by Dependabot also result in visual regression testing with Chromatic.

This configuration change allows Dependabot to only make a single pull request for a few dependencies.

All (other) dependencies are updated manually during patch rounds.