### PR TITLE
Configure npm-check-updates to have a cooldown of 1 day

### DIFF
--- a/.changeset/six-paths-speak.md
+++ b/.changeset/six-paths-speak.md
@@ -1,0 +1,4 @@
+---
+---
+
+Configure `npm-check-updates` to have a [cooldown](https://github.com/raineorshine/npm-check-updates/releases/tag/v18.2.0) of 1 day

--- a/.ncurc.patch.cjs
+++ b/.ncurc.patch.cjs
@@ -1,4 +1,5 @@
 module.exports = {
+  cooldown: 1, // 1 day
   dep: ["dev", "prod"],
   install: "always",
   reject: [],

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "husky": "9.1.7",
     "lint-staged": "16.1.6",
     "markdownlint-cli": "0.45.0",
-    "npm-check-updates": "18.0.3",
+    "npm-check-updates": "19.0.0",
     "npm-package-json-lint": "8.0.0",
     "npm-run-all": "4.1.5",
     "postcss": "8.5.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,8 +52,8 @@ importers:
         specifier: 0.45.0
         version: 0.45.0
       npm-check-updates:
-        specifier: 18.0.3
-        version: 18.0.3
+        specifier: 19.0.0
+        version: 19.0.0
       npm-package-json-lint:
         specifier: 8.0.0
         version: 8.0.0(typescript@5.9.2)
@@ -5875,9 +5875,9 @@ packages:
     resolution: {integrity: sha512-Vq0eyEQy+elFpzsKjMss9kxqb9tG3YHg4dsyWuUENuzvSUWe1TCnW/vV9FkhvBk/brEDoDiVd+M1Btosa6ImdQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
-  npm-check-updates@18.0.3:
-    resolution: {integrity: sha512-IMZWxgAa5gpDVEle2KOZOMLfCu2/9FV+xsXQjPFt2OV0dyZixn0OJrZ9NxUcWgr/ZTGogmZtE0Cb8x2wlsVULg==}
-    engines: {node: ^18.18.0 || >=20.0.0, npm: '>=8.12.1'}
+  npm-check-updates@19.0.0:
+    resolution: {integrity: sha512-qcfjZEv6xB+WvW24S8wU1MKISPPiTREraBg62XDo/7zmOLXH3Zj7ti2v/LRfks0qITU8SDZLTWwgIitflvursw==}
+    engines: {node: '>=20.0.0', npm: '>=8.12.1'}
     hasBin: true
 
   npm-install-checks@6.1.1:
@@ -14245,7 +14245,7 @@ snapshots:
     dependencies:
       npm-normalize-package-bin: 3.0.1
 
-  npm-check-updates@18.0.3: {}
+  npm-check-updates@19.0.0: {}
 
   npm-install-checks@6.1.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,11 +1,35 @@
+# Edit this file by hand. Using `pnpm config` reformats the file and removes all comments.
+
 packages:
-  - "wicket/"
-  - "wicket/**"
-  - "components/**"
-  - "packages/*"
-  - "proprietary/*"
+  - 'wicket/'
+  - 'wicket/**'
+  - 'components/**'
+  - 'packages/*'
+  - 'proprietary/*'
+
+# Configure pnpm so peer dependencies must be explicitly added instead of being automatically installed.
+autoInstallPeers: false
+
+# Configure pnpm so that it will not install any package that claims to not be compatible with the current Node.js
+# version.
+engineStrict: true
 
 # Configure pnpm so it only installs package versions that have been published on the npm registry for at least 24 hours
 # (1440 minutes). This helps mitigate the risk of supply chain attacks by avoiding newly published, potentially
 # malicious versions. Keep this in sync with npm-check-updates's `cooldown` configuration.
 minimumReleaseAge: 1440
+
+# Make an exception for trusted packages, notably our own
+minimumReleaseAgeExclude:
+  - '@nl-design-system/*'
+  - '@nl-design-system-candidate/*'
+  - '@nl-design-system-community/*'
+  - '@nl-design-system-unstable/*'
+
+# Configure pnpm to save exact version numbers (not including ^ or ~) in package.json. Lock dependencies to specific
+# versions to ensure reproducible installs and prevent automatic upgrades to newer minor or patch releases.
+saveExact: true
+savePrefix: ''
+
+# Configure pnpm to not fail when there are missing or invalid peer dependencies in the tree.
+strictPeerDependencies: false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,8 @@ packages:
   - "components/**"
   - "packages/*"
   - "proprietary/*"
+
+# Configure pnpm so it only installs package versions that have been published on the npm registry for at least 24 hours
+# (1440 minutes). This helps mitigate the risk of supply chain attacks by avoiding newly published, potentially
+# malicious versions. Keep this in sync with npm-check-updates's `cooldown` configuration.
+minimumReleaseAge: 1440


### PR DESCRIPTION
Configure npm-check-updates to ignore packages less than a day old.  This is to prevent [supply chain attacks](https://tweakers.net/reviews/13812/wat-zijn-npm-packages-en-waarom-richten-hackers-zich-erop.html).

ncu was updated to 19.0.0 (feature is in [18.2.0](https://github.com/raineorshine/npm-check-updates/releases/tag/v18.2.0)); breaking changes were not applicable (node >= 20, removed `ncu -ws`).

As a bonus I synchronized pnpm-workspace so that you additionally benefit from secure defaults