### PR TITLE
build: avoid provenance for private and restricted packages

### DIFF
--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -10,6 +10,7 @@
   "private": true,
   "publishConfig": {
     "access": "restricted",
+    "provenance": false,
     "registry": "https://registry.npmjs.org/"
   },
   "repository": {

--- a/proprietary/font/package.json
+++ b/proprietary/font/package.json
@@ -11,6 +11,7 @@
   "private": false,
   "publishConfig": {
     "access": "restricted",
+    "provenance": false,
     "registry": "https://registry.npmjs.org/"
   },
   "files": [

--- a/wicket/components-wicket/package.json
+++ b/wicket/components-wicket/package.json
@@ -10,6 +10,7 @@
   "private": true,
   "publishConfig": {
     "access": "restricted",
+    "provenance": false,
     "registry": "https://registry.npmjs.org/"
   },
   "repository": {

--- a/wicket/package.json
+++ b/wicket/package.json
@@ -8,6 +8,7 @@
     "nl-design-system",
     "Apache Wicket"
   ],
+  "private": true,
   "repository": {
     "type": "git+ssh",
     "url": "git@github.com:nl-design-system/rotterdam.git",


### PR DESCRIPTION
Fixes the following error during publication:

```
> changeset publish

🦋  info npm info @gemeente-rotterdam/design-tokens
🦋  info npm info @gemeente-rotterdam/font
🦋  info npm info @gemeente-rotterdam/wicket
🦋  warn Received 404 for npm info "@gemeente-rotterdam/font"
🦋  warn Received 404 for npm info "@gemeente-rotterdam/wicket"
🦋  info @gemeente-rotterdam/design-tokens is being published because our local version (1.0.0) has not been published on npm
🦋  info @gemeente-rotterdam/font is being published because our local version (1.0.0-alpha.4) has not been published on npm
🦋  info @gemeente-rotterdam/wicket is being published because our local version (0.0.1-alpha.13) has not been published on npm
🦋  info Publishing "@gemeente-rotterdam/design-tokens" at "1.0.0"
🦋  info Publishing "@gemeente-rotterdam/font" at "1.0.0-alpha.4"
🦋  info Publishing "@gemeente-rotterdam/wicket" at "0.0.1-alpha.13"
🦋  error an error occurred while publishing @gemeente-rotterdam/font: EUSAGE Can't generate provenance for new or private package, you must set `access` to public. 
🦋  error npm warn Unknown cli config "--git-checks". This will stop working in the next major version of npm.
🦋  error npm warn Unknown env config "verify-deps-before-run". This will stop working in the next major version of npm.
🦋  error npm warn Unknown env config "minimum-release-age". This will stop working in the next major version of npm.
🦋  error npm warn Unknown env config "_jsr-registry". This will stop working in the next major version of npm.
🦋  error npm warn Unknown project config "strict-peer-dependencies". This will stop working in the next major version of npm.
🦋  error npm warn Unknown project config "auto-install-peers". This will stop working in the next major version of npm.
🦋  error npm notice SECURITY NOTICE: Breaking changes starting October 13, 2025. New tokens will be limited to a maximum lifetime of 90 days, and TOTP setup will be disabled. Classic tokens will be revoked in November. Update your CI/CD workflows to avoid disruption. Learn more: https://gh.io/npm-token-changes
🦋  error npm notice Publishing to https://registry.npmjs.org/ with tag latest and restricted access
🦋  error npm error code EUSAGE
🦋  error npm error Can't generate provenance for new or private package, you must set `access` to public.
🦋  error npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2025-10-27T08_23_54_857Z-debug-0.log
🦋  error 
🦋  error an error occurred while publishing @gemeente-rotterdam/wicket: EUSAGE Can't generate provenance for new or private package, you must set `access` to public. 
🦋  error npm warn Unknown cli config "--git-checks". This will stop working in the next major version of npm.
🦋  error npm warn Unknown env config "verify-deps-before-run". This will stop working in the next major version of npm.
🦋  error npm warn Unknown env config "minimum-release-age". This will stop working in the next major version of npm.
🦋  error npm warn Unknown env config "_jsr-registry". This will stop working in the next major version of npm.
🦋  error npm warn Unknown project config "strict-peer-dependencies". This will stop working in the next major version of npm.
🦋  error npm warn Unknown project config "auto-install-peers". This will stop working in the next major version of npm.
🦋  error npm notice SECURITY NOTICE: Breaking changes starting October 13, 2025. New tokens will be limited to a maximum lifetime of 90 days, and TOTP setup will be disabled. Classic tokens will be revoked in November. Update your CI/CD workflows to avoid disruption. Learn more: https://gh.io/npm-token-changes
🦋  error npm notice Publishing to https://registry.npmjs.org/ with tag latest and restricted access
🦋  error npm error code EUSAGE
🦋  error npm error Can't generate provenance for new or private package, you must set `access` to public.
🦋  error npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2025-10-27T08_23_55_369Z-debug-0.log
🦋  error 
🦋  success packages published successfully:
🦋  @gemeente-rotterdam/design-tokens@1.0.0
🦋  Creating git tag...
🦋  New tag:  @gemeente-rotterdam/design-tokens@1.0.0
🦋  error packages failed to publish:
🦋  @gemeente-rotterdam/font@1.0.0-alpha.4
🦋  @gemeente-rotterdam/wicket@0.0.1-alpha.13
 ELIFECYCLE  Command failed with exit code 1.
```