### PR TITLE
build: switch from alpha to semantic versioning

### DIFF
--- a/.changeset/eight-insects-pick.md
+++ b/.changeset/eight-insects-pick.md
@@ -1,0 +1,5 @@
+---
+"@gemeente-rotterdam/font": patch
+---
+
+Switch from alpha to semantic versioning.


### PR DESCRIPTION
Hopefully fixes this error:

```
🦋  info @gemeente-rotterdam/font is being published because our local version (1.0.0-alpha.4) has not been published on npm
🦋  info Publishing "@gemeente-rotterdam/font" at "1.0.0-alpha.4"
🦋  error an error occurred while publishing @gemeente-rotterdam/font: E403 403 Forbidden - PUT https://registry.npmjs.org/@gemeente-rotterdam%2ffont - You cannot publish over the previously published versions: 1.0.0-alpha.4. 
🦋  error In most cases, you or one of your dependencies are requesting
🦋  error a package version that is forbidden by your security policy, or
🦋  error on a server you do not have access to.
🦋  error npm warn Unknown cli config "--git-checks". This will stop working in the next major version of npm.
🦋  error npm warn Unknown env config "verify-deps-before-run". This will stop working in the next major version of npm.
🦋  error npm warn Unknown env config "minimum-release-age". This will stop working in the next major version of npm.
🦋  error npm warn Unknown env config "_jsr-registry". This will stop working in the next major version of npm.
🦋  error npm warn Unknown project config "strict-peer-dependencies". This will stop working in the next major version of npm.
🦋  error npm warn Unknown project config "auto-install-peers". This will stop working in the next major version of npm.
🦋  error npm notice SECURITY NOTICE: Breaking changes starting October 13, 2025. New tokens will be limited to a maximum lifetime of 90 days, and TOTP setup will be disabled. Classic tokens will be revoked in November. Update your CI/CD workflows to avoid disruption. Learn more: https://gh.io/npm-token-changes
🦋  error npm notice Publishing to https://registry.npmjs.org/ with tag latest and restricted access
🦋  error npm error code E403
🦋  error npm error 403 403 Forbidden - PUT https://registry.npmjs.org/@gemeente-rotterdam%2ffont - You cannot publish over the previously published versions: 1.0.0-alpha.4.
🦋  error npm error 403 In most cases, you or one of your dependencies are requesting
🦋  error npm error 403 a package version that is forbidden by your security policy, or
🦋  error npm error 403 on a server you do not have access to.
🦋  error npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2025-10-27T09_26_55_500Z-debug-0.log
🦋  error 
🦋  error packages failed to publish:
🦋  @gemeente-rotterdam/font@1.0.0-alpha.4
 ELIFECYCLE  Command failed with exit code 1.
```