### PR TITLE
ci: use actions/deploy-pages (and replace JamesIves/github-pages-deploy-action) to deploy storybook

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -99,6 +99,11 @@ jobs:
           path: packages/storybook/dist/
           retention-days: 1
 
+      - name: Upload artifact for GitHub Pages
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
+        with:
+          path: packages/storybook/dist/
+
   test:
     runs-on: ubuntu-latest
     needs: install
@@ -162,21 +167,17 @@ jobs:
     needs: build
     if: github.ref == 'refs/heads/main'
 
+    permissions:
+      id-token: write
+      pages: write
+
     steps:
       - name: Checkout release branch
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      - name: "Restore build artifact: Storybook"
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
-        with:
-          name: storybook
-          path: packages/storybook/dist/
-
-      - name: Continuous Deployment to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@6c2d9db40f9296374acc17b90404b6e8864128c8 # v4.7.3
-        with:
-          branch: gh-pages
-          folder: packages/storybook/dist/
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
+        id: deploy-pages
 
   publish-npm:
     runs-on: ubuntu-latest


### PR DESCRIPTION
It is safer to use the action officially created and supported by GitHub itself.
