### PR TITLE
ci: extend permissions to fix publish pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -212,7 +212,9 @@ jobs:
     environment: publish
 
     permissions:
-      id-token: write
+      contents: read # since GH_TOKEN is provided, we only need 'read'
+      pull-requests: write # Needed to create and update pull requests
+      id-token: write # https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions
 
     steps:
       - name: Checkout release branch


### PR DESCRIPTION
permissions align with other repositories, for example

https://github.com/nl-design-system/candidate/blob/main/.github/workflows/publish.yml