### PR TITLE
fix(date-picker): include es2022 lib in tsconfig

### DIFF
--- a/packages/web-components/date-picker/tsconfig.json
+++ b/packages/web-components/date-picker/tsconfig.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
     "outDir": "./dist/",
-    "lib": ["dom"],
+    "lib": ["dom", "es2022"],
     "module": "Preserve",
     "moduleResolution": "bundler"
   },


### PR DESCRIPTION
Required to support Array.at()

Fixes:
```
pnpm run --filter @gemeente-rotterdam/date-picker-element lint
```