### PR TITLE
chore: upgrade pnpm to 10.28.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "engines": {
     "node": ">=24 <=25",
-    "pnpm": "^10"
+    "pnpm": "^10.17.0"
   },
   "workspaces": [
     "./rotterdam-nlds-parent-wicket/",

--- a/package.json
+++ b/package.json
@@ -90,5 +90,5 @@
   "dependencies": {
     "http-server": "14.1.1"
   },
-  "packageManager": "pnpm@10.17.0+sha512.fce8a3dd29a4ed2ec566fb53efbb04d8c44a0f05bc6f24a73046910fb9c3ce7afa35a0980500668fa3573345bd644644fa98338fa168235c80f4aa17aa17fbef"
+  "packageManager": "pnpm@10.28.1+sha512.7d7dbbca9e99447b7c3bf7a73286afaaf6be99251eb9498baefa7d406892f67b879adb3a1d7e687fc4ccc1a388c7175fbaae567a26ab44d1067b54fcb0d6a316"
 }


### PR DESCRIPTION
This PR:
- Upgrades pnpm to the latest version
- Ensures that the minimum version (10.17.0) is properly set in package.json; this minimum version is required for security features, to be exact, minimumReleaseAgeExclude patterns