### PR TITLE
Support custom model object types with converters in FormFieldTextInput

### DIFF
--- a/rotterdam-nlds-parent-wicket/docs-wicket/src/main/java/nl/rotterdam/nl_design_system/docs/wicket/DocsApplication.java
+++ b/rotterdam-nlds-parent-wicket/docs-wicket/src/main/java/nl/rotterdam/nl_design_system/docs/wicket/DocsApplication.java
@@ -2,9 +2,13 @@ package nl.rotterdam.nl_design_system.docs.wicket;
 
 import de.agilecoders.wicket.webjars.WicketWebjars;
 import nl.rotterdam.nl_design_system.docs.wicket.component_examples.ComponentsExamplePage;
+import nl.rotterdam.nl_design_system.docs.wicket.form_field_text_input.person_full_name.PersonFullName;
+import nl.rotterdam.nl_design_system.docs.wicket.form_field_text_input.person_full_name.PersonFullNameWicketConverter;
 import nl.rotterdam.nl_design_system.wicket.html.WicketElementDisplayContentsHeaderContributor;
 import nl.rotterdam.nl_design_system.docs.wicket.mijn_loket_page.MijnLoketPage;
 import nl.rotterdam.nl_design_system.docs.wicket.sso_login_page.SingleSignOnLoginPage;
+import org.apache.wicket.ConverterLocator;
+import org.apache.wicket.IConverterLocator;
 import org.apache.wicket.Session;
 import org.apache.wicket.csp.CSPDirective;
 import org.apache.wicket.csp.CSPDirectiveSrcValue;
@@ -14,16 +18,21 @@ import org.apache.wicket.request.Request;
 import org.apache.wicket.request.Response;
 import org.apache.wicket.settings.ExceptionSettings;
 
-import java.util.Locale;
-
 public class DocsApplication extends WebApplication {
-
-    private static final Locale LOCALE_DUTCH = Locale.of("nl");
 
     @Override
     public Session newSession(Request request, Response response) {
-        return super.newSession(request, response).setLocale(LOCALE_DUTCH);
+        return super.newSession(request, response).setLocale(DocsLocale.LOCALE_DUTCH);
     }
+
+    @Override
+    protected IConverterLocator newConverterLocator() {
+        ConverterLocator locator = (ConverterLocator) super.newConverterLocator();
+
+        locator.set(PersonFullName.class, new PersonFullNameWicketConverter());
+        return locator;
+    }
+
 
     @Override
     public void init() {

--- a/rotterdam-nlds-parent-wicket/docs-wicket/src/main/java/nl/rotterdam/nl_design_system/docs/wicket/DocsLocale.java
+++ b/rotterdam-nlds-parent-wicket/docs-wicket/src/main/java/nl/rotterdam/nl_design_system/docs/wicket/DocsLocale.java
@@ -1,0 +1,10 @@
+package nl.rotterdam.nl_design_system.docs.wicket;
+
+import java.util.Locale;
+
+public class DocsLocale {
+    public static final Locale LOCALE_DUTCH = Locale.of("nl");
+
+    private DocsLocale() {}
+
+}

--- a/rotterdam-nlds-parent-wicket/docs-wicket/src/main/java/nl/rotterdam/nl_design_system/docs/wicket/form_field_text_input/FormFieldTextInputExamplesPanel.html
+++ b/rotterdam-nlds-parent-wicket/docs-wicket/src/main/java/nl/rotterdam/nl_design_system/docs/wicket/form_field_text_input/FormFieldTextInputExamplesPanel.html
@@ -14,7 +14,60 @@
         <section data-testid="formFieldTextInput">
           <h2>Form Field Text Input</h2>
           <rods-story-canvas
-            ><template> <div wicket:id="formFieldTextInput"></div> </template>
+          ><template> <div wicket:id="formFieldTextInput"></div> </template>
+          </rods-story-canvas>
+        </section>
+
+
+        <section data-testid="formFieldTextInputWithValueType">
+          <h2>Form Field Text Input met Value Type</h2>
+
+          <p>
+            In dit voorbeeld gebruikt het formulier geen <code>String</code>, maar het
+            domeintype <code>PersonFullName</code>. Dit value type vertegenwoordigt de
+            volledige naam van een persoon en bevat zelf de validatieregels.
+          </p>
+
+          <p>
+            In het <code>PersonFullName</code> type worden bijvoorbeeld constraints
+            afgedwongen zoals een minimale en maximale lengte van de naam. Hierdoor
+            kan een ongeldige naam niet in het domeinmodel terechtkomen.
+          </p>
+
+          <p>
+            Formulieren werken in de browser altijd met tekst (<code>String</code>).
+            Daarom gebruikt Wicket een <code>IConverter</code> om de invoer uit het
+            formulier te converteren naar het value type
+            <code>PersonFullName</code>. In deze converter worden eventuele
+            validatiefouten vertaald naar gebruikersvriendelijke foutmeldingen.
+          </p>
+
+          <p>
+            Het gebruik van value types kost iets meer implementatietijd
+            (bijvoorbeeld converters en integratie met frameworks),
+            maar levert op lange termijn duidelijke voordelen op:
+          </p>
+
+          <ul>
+            <li>betere type safety in het domeinmodel</li>
+            <li>validatie op één centrale plek</li>
+            <li>duidelijkere betekenis van waarden in de code</li>
+            <li>minder kans op bugs door verkeerd gebruik van <code>String</code></li>
+          </ul>
+
+          <p>
+            In dit voorbeeld wordt de tekstinvoer uit het formulier automatisch
+            geconverteerd naar een <code>PersonFullName</code> en opgeslagen
+            in het formuliermodel.
+          </p>
+
+          <rods-story-canvas
+          ><template>
+            <form wicket:id="formFieldTextInputWithValueType" class="d-flex flex-column gap-3 col-lg-5">
+              <div wicket:id="personFullName"/>
+              <button wicket:id="submit" type="submit">Verzenden</button>
+            </form>
+          </template>
           </rods-story-canvas>
         </section>
 

--- a/rotterdam-nlds-parent-wicket/docs-wicket/src/main/java/nl/rotterdam/nl_design_system/docs/wicket/form_field_text_input/FormFieldTextInputExamplesPanel.java
+++ b/rotterdam-nlds-parent-wicket/docs-wicket/src/main/java/nl/rotterdam/nl_design_system/docs/wicket/form_field_text_input/FormFieldTextInputExamplesPanel.java
@@ -1,12 +1,19 @@
 package nl.rotterdam.nl_design_system.docs.wicket.form_field_text_input;
 
+import nl.rotterdam.nl_design_system.docs.wicket.form_field_text_input.person_full_name.PersonFullName;
+import nl.rotterdam.nl_design_system.wicket.components.button.RdButton;
 import nl.rotterdam.nl_design_system.wicket.components.form_field_text_input.RdFormFieldTextInput;
 import nl.rotterdam.nl_design_system.wicket.components.models.DefaultModels;
 import nl.rotterdam.nl_design_system.docs.wicket.ComponentExample;
 import nl.rotterdam.nl_design_system.docs.wicket.ExamplesPanel;
 import org.apache.wicket.AttributeModifier;
+import org.apache.wicket.markup.html.form.Form;
+import org.apache.wicket.model.LambdaModel;
 import org.apache.wicket.model.Model;
+import org.apache.wicket.model.ResourceModel;
 import org.jspecify.annotations.Nullable;
+
+import java.io.Serializable;
 
 public class FormFieldTextInputExamplesPanel extends ExamplesPanel {
     public FormFieldTextInputExamplesPanel(String id) {
@@ -27,6 +34,41 @@ public class FormFieldTextInputExamplesPanel extends ExamplesPanel {
             Model.of("Vul je voornaam in.")
         );
     }
+    @ComponentExample
+    private static Form<Void> exampleFormFieldTextInputWithValueType() {
+
+        class PersonFullNameFormDto implements Serializable {
+
+            @Nullable
+            private PersonFullName personFullName;
+
+            public @Nullable PersonFullName getPersonFullName() {
+                return personFullName;
+            }
+
+            public void setPersonFullName(PersonFullName personFullName) {
+                this.personFullName = personFullName;
+            }
+        }
+
+        return new Form<>("formFieldTextInputWithValueType") {
+
+            @Override
+            protected void onInitialize() {
+                super.onInitialize();
+                var model = Model.of(new PersonFullNameFormDto());
+                add(new RdFormFieldTextInput<>(
+                    "personFullName",
+                    LambdaModel.of(model, PersonFullNameFormDto::getPersonFullName, PersonFullNameFormDto::setPersonFullName),
+                    new ResourceModel("PersonFullName.label")
+
+                )
+                .setModelType(PersonFullName.class),
+                new RdButton("submit", new ResourceModel("Submit.label"))
+                );
+            }
+        };
+    }
 
     @ComponentExample
     private static RdFormFieldTextInput<@Nullable String> exampleFormFieldTextInputRequired() {
@@ -35,7 +77,7 @@ public class FormFieldTextInputExamplesPanel extends ExamplesPanel {
             DefaultModels.NULL_STRING_MODEL,
             Model.of("Email")
         )
-            .setInputType("email")
+            .setHtmlInputType("email")
             .setRequired(true);
     }
 
@@ -72,6 +114,7 @@ public class FormFieldTextInputExamplesPanel extends ExamplesPanel {
 
         add(
             exampleFormFieldTextInput(),
+            exampleFormFieldTextInputWithValueType(),
             exampleFormFieldTextInputRequired(),
             exampleFormFieldTextInputDisabled(),
             exampleFormFieldTextInputWithAutocompleteConfigured()

--- a/rotterdam-nlds-parent-wicket/docs-wicket/src/main/java/nl/rotterdam/nl_design_system/docs/wicket/form_field_text_input/FormFieldTextInputExamplesPanel.properties.xml
+++ b/rotterdam-nlds-parent-wicket/docs-wicket/src/main/java/nl/rotterdam/nl_design_system/docs/wicket/form_field_text_input/FormFieldTextInputExamplesPanel.properties.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
+<properties>
+    <entry key="PersonFullName.label">Full name</entry>
+    <entry key="PersonFullName.tooLong">${label} must have at max ${max} characters</entry>
+    <entry key="PersonFullName.tooShort">${label} must have at least ${min} characters</entry>
+    <entry key="Submit.label">Submit</entry>
+</properties>

--- a/rotterdam-nlds-parent-wicket/docs-wicket/src/main/java/nl/rotterdam/nl_design_system/docs/wicket/form_field_text_input/FormFieldTextInputExamplesPanel_nl.properties.xml
+++ b/rotterdam-nlds-parent-wicket/docs-wicket/src/main/java/nl/rotterdam/nl_design_system/docs/wicket/form_field_text_input/FormFieldTextInputExamplesPanel_nl.properties.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
+<properties>
+    <entry key="PersonFullName.label">Volledige naam</entry>
+    <entry key="PersonFullName.tooLong">${label} mag maximaal ${max} tekens bevatten</entry>
+    <entry key="PersonFullName.tooShort">${label} moet minimaal ${min} tekens bevatten</entry>
+    <entry key="Submit.label">Verzenden</entry>
+</properties>

--- a/rotterdam-nlds-parent-wicket/docs-wicket/src/main/java/nl/rotterdam/nl_design_system/docs/wicket/form_field_text_input/person_full_name/PersonFullName.java
+++ b/rotterdam-nlds-parent-wicket/docs-wicket/src/main/java/nl/rotterdam/nl_design_system/docs/wicket/form_field_text_input/person_full_name/PersonFullName.java
@@ -1,0 +1,31 @@
+package nl.rotterdam.nl_design_system.docs.wicket.form_field_text_input.person_full_name;
+
+import java.io.Serializable;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Value type representing a person's full name (first name + last name stored as a single string).
+ * <p>
+ * Validates that the value is more than 4 characters and less than 80 characters.
+ * Throws {@link PersonFullNameTooShortException} or {@link PersonFullNameTooLongException}
+ * when the input does not meet these constraints.
+ */
+public record PersonFullName(String value) implements Serializable {
+
+    public static final int MINIMUM_LENGTH = 5;
+    public static final int MAXIMUM_LENGTH = 80;
+
+    public PersonFullName {
+        requireNonNull(value, "Naam mag niet null zijn");
+        value = value.trim();
+
+        if (value.length() < MINIMUM_LENGTH) {
+            throw new PersonFullNameTooShortException(value);
+        }
+        if (value.length() >= MAXIMUM_LENGTH) {
+            throw new PersonFullNameTooLongException(value);
+        }
+    }
+
+}

--- a/rotterdam-nlds-parent-wicket/docs-wicket/src/main/java/nl/rotterdam/nl_design_system/docs/wicket/form_field_text_input/person_full_name/PersonFullNameTooLongException.java
+++ b/rotterdam-nlds-parent-wicket/docs-wicket/src/main/java/nl/rotterdam/nl_design_system/docs/wicket/form_field_text_input/person_full_name/PersonFullNameTooLongException.java
@@ -1,0 +1,8 @@
+package nl.rotterdam.nl_design_system.docs.wicket.form_field_text_input.person_full_name;
+
+public class PersonFullNameTooLongException extends RuntimeException {
+
+    public PersonFullNameTooLongException(String value) {
+        super("Naam is te lang: " + value.length() + " tekens (maximaal " + PersonFullName.MAXIMUM_LENGTH  + " tekens toegestaan)");
+    }
+}

--- a/rotterdam-nlds-parent-wicket/docs-wicket/src/main/java/nl/rotterdam/nl_design_system/docs/wicket/form_field_text_input/person_full_name/PersonFullNameTooShortException.java
+++ b/rotterdam-nlds-parent-wicket/docs-wicket/src/main/java/nl/rotterdam/nl_design_system/docs/wicket/form_field_text_input/person_full_name/PersonFullNameTooShortException.java
@@ -1,0 +1,8 @@
+package nl.rotterdam.nl_design_system.docs.wicket.form_field_text_input.person_full_name;
+
+public class PersonFullNameTooShortException extends RuntimeException {
+
+    public PersonFullNameTooShortException(String value) {
+        super("Naam is te kort: '" + value + "' (minimaal " + PersonFullName.MAXIMUM_LENGTH + " tekens vereist)");
+    }
+}

--- a/rotterdam-nlds-parent-wicket/docs-wicket/src/main/java/nl/rotterdam/nl_design_system/docs/wicket/form_field_text_input/person_full_name/PersonFullNameWicketConverter.java
+++ b/rotterdam-nlds-parent-wicket/docs-wicket/src/main/java/nl/rotterdam/nl_design_system/docs/wicket/form_field_text_input/person_full_name/PersonFullNameWicketConverter.java
@@ -1,0 +1,35 @@
+package nl.rotterdam.nl_design_system.docs.wicket.form_field_text_input.person_full_name;
+
+import org.apache.wicket.util.convert.ConversionException;
+import org.apache.wicket.util.convert.IConverter;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Locale;
+
+public class PersonFullNameWicketConverter implements IConverter<PersonFullName> {
+
+    @Override
+    public @Nullable PersonFullName convertToObject(String value, Locale locale) throws ConversionException {
+        if (value.isBlank()) {
+            return null;
+        }
+        try {
+            return new PersonFullName(value);
+        } catch (PersonFullNameTooShortException e) {
+            throw new ConversionException("Naam moet minimaal 5 tekens bevatten")
+                    .setResourceKey("PersonFullName.tooShort")
+                    .setVariable("min", PersonFullName.MINIMUM_LENGTH)
+                    .setLocale(locale);
+        } catch (PersonFullNameTooLongException e) {
+            throw new ConversionException("Naam moet maximaal 79 tekens bevatten")
+                    .setResourceKey("PersonFullName.tooLong")
+                    .setVariable("max", PersonFullName.MAXIMUM_LENGTH)
+                    .setLocale(locale);
+        }
+    }
+
+    @Override
+    public String convertToString(PersonFullName value, Locale locale) {
+        return value.value();
+    }
+}

--- a/rotterdam-nlds-parent-wicket/docs-wicket/src/main/java/nl/rotterdam/nl_design_system/docs/wicket/sso_login_page/SingleSignOnLoginFormPanel.java
+++ b/rotterdam-nlds-parent-wicket/docs-wicket/src/main/java/nl/rotterdam/nl_design_system/docs/wicket/sso_login_page/SingleSignOnLoginFormPanel.java
@@ -37,7 +37,7 @@ public class SingleSignOnLoginFormPanel extends Panel {
                         new RdFormFieldTextInput<>("username", username, Model.of("Gebruikersnaam")).setRequired(true),
                         new RdFormFieldTextInput<>("password", password, Model.of("Wachtwoord"))
                             .setRequired(true)
-                            .setInputType("password"),
+                            .setHtmlInputType("password"),
                         new RdFormFieldCheckbox("rememberMe", rememberMe, Model.of("Onthoud mij")).setRequired(true),
                         newMinLength8(sampleMinLength8),
                         new RdActionGroup("actionGroup").add(new RdButton("submit"))

--- a/rotterdam-nlds-parent-wicket/docs-wicket/src/test/java/nl/rotterdam/nl_design_system/docs/wicket/ComponentsPageTest.java
+++ b/rotterdam-nlds-parent-wicket/docs-wicket/src/test/java/nl/rotterdam/nl_design_system/docs/wicket/ComponentsPageTest.java
@@ -1,6 +1,5 @@
 package nl.rotterdam.nl_design_system.docs.wicket;
 
-import nl.rotterdam.nl_design_system.wicket.test_common.NldsWicketTestCase;
 import nl.rotterdam.nl_design_system.wicket.test_common.WicketAssertions;
 import org.apache.wicket.markup.head.HeaderItem;
 import org.apache.wicket.markup.head.IHeaderResponse;
@@ -13,7 +12,7 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-class ComponentsPageTest extends NldsWicketTestCase {
+class ComponentsPageTest extends DocsWicketTestCase {
 
     @Test
     void pageRenders() {

--- a/rotterdam-nlds-parent-wicket/docs-wicket/src/test/java/nl/rotterdam/nl_design_system/docs/wicket/DocsWicketTestCase.java
+++ b/rotterdam-nlds-parent-wicket/docs-wicket/src/test/java/nl/rotterdam/nl_design_system/docs/wicket/DocsWicketTestCase.java
@@ -1,0 +1,13 @@
+package nl.rotterdam.nl_design_system.docs.wicket;
+
+import nl.rotterdam.nl_design_system.wicket.test_common.NldsWicketTestCase;
+import org.apache.wicket.protocol.http.WebApplication;
+import org.jspecify.annotations.NonNull;
+
+public class DocsWicketTestCase extends NldsWicketTestCase {
+
+    @Override
+    protected @NonNull WebApplication newApplication() {
+        return new DocsApplication();
+    }
+}

--- a/rotterdam-nlds-parent-wicket/docs-wicket/src/test/java/nl/rotterdam/nl_design_system/docs/wicket/component_examples/ComponentsExamplePageTest.java
+++ b/rotterdam-nlds-parent-wicket/docs-wicket/src/test/java/nl/rotterdam/nl_design_system/docs/wicket/component_examples/ComponentsExamplePageTest.java
@@ -1,9 +1,9 @@
 package nl.rotterdam.nl_design_system.docs.wicket.component_examples;
 
+import nl.rotterdam.nl_design_system.docs.wicket.DocsWicketTestCase;
 import nl.rotterdam.nl_design_system.docs.wicket.action_group.ActionGroupExamplesPanel;
 import nl.rotterdam.nl_design_system.docs.wicket.form_field_checkbox.FormFieldCheckboxExamplesPanel;
 import nl.rotterdam.nl_design_system.docs.wicket.link.LinkExamplesPanel;
-import nl.rotterdam.nl_design_system.wicket.test_common.NldsWicketTestCase;
 import nl.rotterdam.nl_design_system.wicket.test_common.WicketAssertions;
 import org.apache.wicket.markup.head.HeaderItem;
 import org.apache.wicket.markup.head.IHeaderResponse;
@@ -24,7 +24,7 @@ import static nl.rotterdam.nl_design_system.docs.wicket.component_examples.Compo
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 
-class ComponentsExamplePageTest extends NldsWicketTestCase {
+class ComponentsExamplePageTest extends DocsWicketTestCase {
 
     @Test
     void rendersWithoutComponentParameter() {

--- a/rotterdam-nlds-parent-wicket/docs-wicket/src/test/java/nl/rotterdam/nl_design_system/docs/wicket/css/BootstrapCssReferenceTest.java
+++ b/rotterdam-nlds-parent-wicket/docs-wicket/src/test/java/nl/rotterdam/nl_design_system/docs/wicket/css/BootstrapCssReferenceTest.java
@@ -1,12 +1,12 @@
 package nl.rotterdam.nl_design_system.docs.wicket.css;
 
+import nl.rotterdam.nl_design_system.docs.wicket.DocsWicketTestCase;
 import nl.rotterdam.nl_design_system.docs.wicket.css.bootstrap.BootstrapCssReference;
-import nl.rotterdam.nl_design_system.wicket.test_common.NldsWicketTestCase;
 import org.junit.jupiter.api.Test;
 
 import static nl.rotterdam.nl_design_system.wicket.test_common.WicketAssertions.assertHeaderItemExists;
 
-class BootstrapCssReferenceTest extends NldsWicketTestCase {
+class BootstrapCssReferenceTest extends DocsWicketTestCase {
 
     @Test
     void assertExists() {

--- a/rotterdam-nlds-parent-wicket/docs-wicket/src/test/java/nl/rotterdam/nl_design_system/docs/wicket/css/NldsVoorbeeldGemeenteThemeCssReferenceTest.java
+++ b/rotterdam-nlds-parent-wicket/docs-wicket/src/test/java/nl/rotterdam/nl_design_system/docs/wicket/css/NldsVoorbeeldGemeenteThemeCssReferenceTest.java
@@ -2,10 +2,10 @@ package nl.rotterdam.nl_design_system.docs.wicket.css;
 
 import static nl.rotterdam.nl_design_system.wicket.test_common.WicketAssertions.assertHeaderItemExists;
 
-import nl.rotterdam.nl_design_system.wicket.test_common.NldsWicketTestCase;
+import nl.rotterdam.nl_design_system.docs.wicket.DocsWicketTestCase;
 import org.junit.jupiter.api.Test;
 
-class NldsVoorbeeldGemeenteThemeCssReferenceTest extends NldsWicketTestCase {
+class NldsVoorbeeldGemeenteThemeCssReferenceTest extends DocsWicketTestCase {
 
     @Test
     void assertCssExists() {

--- a/rotterdam-nlds-parent-wicket/docs-wicket/src/test/java/nl/rotterdam/nl_design_system/docs/wicket/form_field_text_input/FormFieldTextInputExamplesPanelTest.java
+++ b/rotterdam-nlds-parent-wicket/docs-wicket/src/test/java/nl/rotterdam/nl_design_system/docs/wicket/form_field_text_input/FormFieldTextInputExamplesPanelTest.java
@@ -1,0 +1,35 @@
+package nl.rotterdam.nl_design_system.docs.wicket.form_field_text_input;
+
+import nl.rotterdam.nl_design_system.docs.wicket.DocsWicketTestCase;
+import org.junit.jupiter.api.Test;
+
+import java.util.Locale;
+
+import static nl.rotterdam.nl_design_system.docs.wicket.DocsLocale.LOCALE_DUTCH;
+
+class FormFieldTextInputExamplesPanelTest  extends DocsWicketTestCase {
+
+    @Test
+    void correctErrorMessageIsRenderedForLocaleEnglish() {
+        tester.startComponentInPage(FormFieldTextInputExamplesPanel.class);
+        tester.getSession().setLocale(Locale.ENGLISH);
+
+        tester.newFormTester("formFieldTextInputWithValueType")
+            .setValue("personFullName:input-container:control", "123")
+            .submit();
+
+        tester.assertErrorMessages("Full name must have at least 5 characters");
+    }
+
+    @Test
+    void correctErrorMessageIsRenderedForLocaleDutch() {
+        tester.startComponentInPage(FormFieldTextInputExamplesPanel.class);
+        tester.getSession().setLocale(LOCALE_DUTCH);
+
+        tester.newFormTester("formFieldTextInputWithValueType")
+            .setValue("personFullName:input-container:control", "123")
+            .submit();
+
+        tester.assertErrorMessages("Volledige naam moet minimaal 5 tekens bevatten");
+    }
+}

--- a/rotterdam-nlds-parent-wicket/docs-wicket/src/test/java/nl/rotterdam/nl_design_system/docs/wicket/mijn_loket_page/MijnLoketPageTest.java
+++ b/rotterdam-nlds-parent-wicket/docs-wicket/src/test/java/nl/rotterdam/nl_design_system/docs/wicket/mijn_loket_page/MijnLoketPageTest.java
@@ -1,10 +1,10 @@
 package nl.rotterdam.nl_design_system.docs.wicket.mijn_loket_page;
 
-import nl.rotterdam.nl_design_system.wicket.test_common.NldsWicketTestCase;
+import nl.rotterdam.nl_design_system.docs.wicket.DocsWicketTestCase;
 import org.junit.jupiter.api.Test;
 
 
-class MijnLoketPageTest extends NldsWicketTestCase {
+class MijnLoketPageTest extends DocsWicketTestCase {
 
     @Test
     void renders() {

--- a/rotterdam-nlds-parent-wicket/rotterdam-nlds-wicket/src/main/java/nl/rotterdam/nl_design_system/wicket/components/form_field_text_input/RdFormFieldTextInput.java
+++ b/rotterdam-nlds-parent-wicket/rotterdam-nlds-wicket/src/main/java/nl/rotterdam/nl_design_system/wicket/components/form_field_text_input/RdFormFieldTextInput.java
@@ -178,9 +178,13 @@ public class RdFormFieldTextInput<T extends @Nullable Object> extends GenericPan
         return textInput;
     }
 
-    public RdFormFieldTextInput<T> setInputType(String type) {
+    public RdFormFieldTextInput<T> setHtmlInputType(String type) {
         inputType = type;
+        return this;
+    }
 
+    public RdFormFieldTextInput<T> setModelType(Class<T> type) {
+        textInput.setType(type);
         return this;
     }
 


### PR DESCRIPTION
It was not working, as there was no explicit way to set modelType (it was possible via an implicit way by calling getTextField() but that makes the API not a good experience to work with)

Also adapted tests of docs-application to run tests with correct Application.