### PR TITLE
Shell: bash niet nodig, bump versie pr niet laten blokkeren door recusiebescherm

### DIFF
--- a/.github/workflows/apache-wicket.yml
+++ b/.github/workflows/apache-wicket.yml
@@ -26,7 +26,6 @@ jobs:
         id: get-date
         run: |
           echo "date=$(/bin/date -u "+%Y%m")" >> $GITHUB_OUTPUT
-        shell: bash
       - name: Cache dependencies
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:

--- a/.github/workflows/maven-central-sonatype.yml
+++ b/.github/workflows/maven-central-sonatype.yml
@@ -18,6 +18,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: publish
     permissions:
       contents: write # needed for branch + commit
       pull-requests: write # needed for PR creation
@@ -156,4 +157,4 @@ jobs:
             --title "$PR_TITLE" \
             --body "$PR_BODY"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/maven-central-sonatype.yml
+++ b/.github/workflows/maven-central-sonatype.yml
@@ -75,7 +75,6 @@ jobs:
           else
             echo "MAVEN_DRY_RUN=" >> $GITHUB_OUTPUT
           fi
-        shell: bash
 
       - name: Check tag vs POM version (only for tag builds)
         if: startsWith(github.ref, 'refs/tags/java-')
@@ -101,7 +100,6 @@ jobs:
             echo "ERROR: tag version and POM version (without -SNAPSHOT) differ"
             exit 1
           fi
-        shell: bash
 
       # --- Release-only steps (tag builds): adjust versions around the deploy ---
 
@@ -109,7 +107,6 @@ jobs:
         run: |
           ./mvnw -B versions:set -DremoveSnapshot -DgenerateBackupPoms=false
           ./mvnw -B versions:commit
-        shell: bash
 
       - name: Publish to Maven Central (Sonatype)
         run: ./mvnw -B -DskipTests -Pcentral-sonatype-release ${{ steps.dryrun.outputs.MAVEN_DRY_RUN }} deploy
@@ -119,7 +116,6 @@ jobs:
         run: |
           ./mvnw -B versions:set -DnextSnapshot -DgenerateBackupPoms=false
           ./mvnw -B versions:commit
-        shell: bash
 
       - name: Create branch for next SNAPSHOT version
         if: startsWith(github.ref, 'refs/tags/java-')
@@ -143,7 +139,6 @@ jobs:
           git push origin "$BRANCH_NAME"
 
           echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
-        shell: bash
 
       - name: Create PR for next SNAPSHOT version
         if: startsWith(github.ref, 'refs/tags/java-')
@@ -162,4 +157,3 @@ jobs:
             --body "$PR_BODY"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        shell: bash


### PR DESCRIPTION
De default shell is waarschijnlijk niet nodig, weggehaald.

Aanpassingen in GitHub action zodat recursie-bescherming uitvoer GitHub Actions niet blokkeert

Closes #523 