### PR TITLE
chore: skip changeset for private packages

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.0.5/schema.json",
-  "baseBranch": "main"
+  "baseBranch": "main",
+  "privatePackages": false
 }


### PR DESCRIPTION
Since private packages are not published to npm, we don't need to run changeset for them.  By not showing them in the changeset list we avoid accidental changesets.