### PR TITLE
Doubly ensure packages are published with provenance

### DIFF
--- a/.changeset/shy-turkeys-tell.md
+++ b/.changeset/shy-turkeys-tell.md
@@ -1,0 +1,7 @@
+---
+"@gemeente-rotterdam/date-picker-element": patch
+"@gemeente-rotterdam/design-tokens": patch
+"@gemeente-rotterdam/font": patch
+---
+
+Doubly ensure packages are published with provenance

--- a/packages/web-components/date-picker/package.json
+++ b/packages/web-components/date-picker/package.json
@@ -14,7 +14,8 @@
     "tokens.json"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/proprietary/design-tokens/package.json
+++ b/proprietary/design-tokens/package.json
@@ -9,7 +9,8 @@
   ],
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/proprietary/font/package.json
+++ b/proprietary/font/package.json
@@ -11,7 +11,7 @@
   "private": false,
   "publishConfig": {
     "access": "restricted",
-    "provenance": false,
+    "provenance": true,
     "registry": "https://registry.npmjs.org/"
   },
   "files": [


### PR DESCRIPTION
This is not strictly necessary, because there are other ways to configure provenance (notably .npmrc), but it helps with automated scripts and gives extra peace of mind.

Note: for the restricted package **font** the flag has been set to true, I am unaware of any downsides. @Robbert 