### PR TITLE
ci: don't persist credentials in actions/checkout

### DIFF
--- a/.github/workflows/apache-wicket.yml
+++ b/.github/workflows/apache-wicket.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Clone Git repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Install Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install pnpm package manager
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
@@ -27,7 +29,7 @@ jobs:
         run: |
           echo "Auditing npm dependencies with pnpm v11 before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
           pnpm dlx pnpm@11.0.0-rc.2 --config.manage-package-manager-versions=false audit --audit-level critical
-      
+
       - name: Check for known security issues with npm packages
         if: vars.ENABLE_PNPM_AUDIT_V11 != '1'
         run: |
@@ -46,6 +48,8 @@ jobs:
     steps:
       - name: Checkout branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install pnpm package manager
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
@@ -60,7 +64,7 @@ jobs:
         run: |
           echo "Auditing npm dependencies with pnpm v11 before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
           pnpm dlx pnpm@11.0.0-rc.2 --config.manage-package-manager-versions=false audit --audit-level critical
-      
+
       - name: Check for known security issues with npm packages
         if: vars.ENABLE_PNPM_AUDIT_V11 != '1'
         run: |
@@ -80,6 +84,8 @@ jobs:
     steps:
       - name: Checkout branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install pnpm package manager
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
@@ -100,7 +106,7 @@ jobs:
         run: |
           echo "Auditing npm dependencies with pnpm v11 before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
           pnpm dlx pnpm@11.0.0-rc.2 --config.manage-package-manager-versions=false audit --audit-level critical
-      
+
       - name: Check for known security issues with npm packages
         if: vars.ENABLE_PNPM_AUDIT_V11 != '1'
         run: |
@@ -147,6 +153,8 @@ jobs:
     steps:
       - name: Checkout branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install pnpm package manager
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
@@ -161,7 +169,7 @@ jobs:
         run: |
           echo "Auditing npm dependencies with pnpm v11 before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
           pnpm dlx pnpm@11.0.0-rc.2 --config.manage-package-manager-versions=false audit --audit-level critical
-      
+
       - name: Check for known security issues with npm packages
         if: vars.ENABLE_PNPM_AUDIT_V11 != '1'
         run: |
@@ -183,6 +191,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install pnpm package manager
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
@@ -197,7 +206,7 @@ jobs:
         run: |
           echo "Auditing npm dependencies with pnpm v11 before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
           pnpm dlx pnpm@11.0.0-rc.2 --config.manage-package-manager-versions=false audit --audit-level critical
-      
+
       - name: Check for known security issues with npm packages
         if: vars.ENABLE_PNPM_AUDIT_V11 != '1'
         run: |


### PR DESCRIPTION
This PR updates the `actions/checkout` action to not persist credentials by default.

This is a security best practice.

See https://github.com/nl-design-system/beheer/issues/31 for more details.
