### PR TITLE
ci: configure dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 1
     groups:
       github-actions:
         applies-to: "version-updates"
@@ -14,6 +16,8 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 1
     groups:
       patch-and-minor-dependencies:
         applies-to: "version-updates"

--- a/.github/workflows/maven-central-sonatype.yml
+++ b/.github/workflows/maven-central-sonatype.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_TOKEN }}
+          persist-credentials: true
 
       - name: Ensure Maven Wrapper is executable
         run: chmod +x mvnw

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -267,6 +267,7 @@ jobs:
           token: ${{ secrets.GH_TOKEN }}
           fetch-tags: true
           fetch-depth: 0
+          persist-credentials: true
 
       - name: Install pnpm package manager
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0


### PR DESCRIPTION
This PR configures the [cooldown](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-) for dependabot updates to 1 day.

This is a security measure that gives the ecosystem enough time to flag malicious packages before they reach our codebase.

It is already configured in pnpm and npm-check-updates, but not in dependabot.  Thanks to zizmor for flagging.
