### PR TITLE
CVE updates

### DIFF
--- a/rotterdam-nlds-parent-wicket/pom.xml
+++ b/rotterdam-nlds-parent-wicket/pom.xml
@@ -9,7 +9,6 @@
     </parent>
 
     <artifactId>rotterdam-nlds-parent-wicket</artifactId>
-    <version>0.1.2-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Rotterdam, NL Design System Wicket Parent</name>
     <description>NL Design System Wicket Parent POM.</description>
@@ -24,8 +23,8 @@
     </modules>
 
     <properties>
-        <jetty.version>12.1.0</jetty.version>
-        <wicket.version>10.6.0</wicket.version>
+        <jetty.version>12.1.10</jetty.version>
+        <wicket.version>10.9.1</wicket.version>
     </properties>
 
     <dependencyManagement>
@@ -78,7 +77,7 @@
                  -->
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
-                <version>2.20.1</version>
+                <version>2.22.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -127,12 +126,12 @@
             <dependency>
                 <groupId>de.agilecoders.wicket.webjars</groupId>
                 <artifactId>wicket-webjars</artifactId>
-                <version>4.0.13</version>
+                <version>4.0.14</version>
             </dependency>
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
-                <version>1.5.20</version>
+                <version>1.5.34</version>
             </dependency>
             <dependency>
                 <groupId>jakarta.servlet</groupId>
@@ -142,14 +141,14 @@
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>5.13.4</version>
+                <version>5.14.4</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>com.github.javaparser</groupId>
                 <artifactId>javaparser-symbol-solver-core</artifactId>
-                <version>3.27.0</version>
+                <version>3.28.2</version>
             </dependency>
             <dependency>
                 <groupId>org.jsoup</groupId>


### PR DESCRIPTION
Wat CVE updates voor Wicket en andere libraries gedaan.

jsoup uitgesloten, test-output is anders